### PR TITLE
SW-5342: Govuk asset path fix

### DIFF
--- a/web/assets/main.scss
+++ b/web/assets/main.scss
@@ -1,6 +1,7 @@
 $govuk-include-default-font-face: false;
 $govuk-moj-table-background-color: #e7f2fb;
 $moj-assets-path: "/supervision/deputies/firm/assets/";
+$govuk-assets-path: "/supervision/deputies/firm/assets/";
 
 @import "node_modules/govuk-frontend/govuk/all";
 @import "node_modules/@ministryofjustice/frontend/moj/all";


### PR DESCRIPTION
Duplicating fix from Pro Hub where misconfigured asset path for govuk images would result in the user credentials being invalidated in Sirius