### PR TITLE
sw-5281-amended firms routing in sirius #minor

### DIFF
--- a/internal/sirius/get_firm_details.go
+++ b/internal/sirius/get_firm_details.go
@@ -7,24 +7,24 @@ import (
 )
 
 type Deputy struct {
-	DeputyId int `json:"id"`
-	DeputyNumber int `json:"deputyNumber"`
+	DeputyId         int    `json:"id"`
+	DeputyNumber     int    `json:"deputyNumber"`
 	OrganisationName string `json:"organisationName"`
 }
 
 type FirmDetails struct {
-	ID           int    `json:"id"`
-	FirmName     string `json:"firmName"`
-	FirmNumber   int    `json:"firmNumber"`
-	Email        string `json:"email"`
-	PhoneNumber  string `json:"phoneNumber"`
-	AddressLine1 string `json:"addressLine1"`
-	AddressLine2 string `json:"addressLine2"`
-	AddressLine3 string `json:"addressLine3"`
-	Town         string `json:"town"`
-	County       string `json:"county"`
-	Postcode     string `json:"postcode"`
-	Deputies     []Deputy `json:"deputies"`
+	ID                    int      `json:"id"`
+	FirmName              string   `json:"firmName"`
+	FirmNumber            int      `json:"firmNumber"`
+	Email                 string   `json:"email"`
+	PhoneNumber           string   `json:"phoneNumber"`
+	AddressLine1          string   `json:"addressLine1"`
+	AddressLine2          string   `json:"addressLine2"`
+	AddressLine3          string   `json:"addressLine3"`
+	Town                  string   `json:"town"`
+	County                string   `json:"county"`
+	Postcode              string   `json:"postcode"`
+	Deputies              []Deputy `json:"deputies"`
 	TotalNumberOfDeputies int
 }
 
@@ -56,4 +56,3 @@ func (c *Client) GetFirmDetails(ctx Context, firmId int) (FirmDetails, error) {
 
 	return v, err
 }
-

--- a/internal/sirius/get_firm_details.go
+++ b/internal/sirius/get_firm_details.go
@@ -31,7 +31,7 @@ type FirmDetails struct {
 func (c *Client) GetFirmDetails(ctx Context, firmId int) (FirmDetails, error) {
 	var v FirmDetails
 
-	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/firm/%d", firmId), nil)
+	req, err := c.newRequest(ctx, http.MethodGet, fmt.Sprintf("/api/v1/firms/%d", firmId), nil)
 
 	if err != nil {
 		return v, err

--- a/internal/sirius/get_firm_details_test.go
+++ b/internal/sirius/get_firm_details_test.go
@@ -126,6 +126,3 @@ func TestGetDeputyDetailsReturnsUnauthorisedClientError(t *testing.T) {
 	assert.Equal(t, ErrUnauthorized, err)
 	assert.Equal(t, expectedResponse, firmDetails)
 }
-
-
-

--- a/internal/sirius/get_firm_details_test.go
+++ b/internal/sirius/get_firm_details_test.go
@@ -106,7 +106,7 @@ func TestGetFirmReturnsNewStatusError(t *testing.T) {
 	assert.Equal(t, expectedResponse, firmDetails)
 	assert.Equal(t, StatusError{
 		Code:   http.StatusMethodNotAllowed,
-		URL:    svr.URL + "/api/v1/firm/1",
+		URL:    svr.URL + "/api/v1/firms/1",
 		Method: http.MethodGet,
 	}, err)
 }

--- a/json-server/db.json
+++ b/json-server/db.json
@@ -10,7 +10,7 @@
             "permissions": ["DELETE"]
         }
     },
-    "firm": {
+    "firms": {
         "id": 1,
         "deputies": [
             {

--- a/json-server/routes.json
+++ b/json-server/routes.json
@@ -1,4 +1,4 @@
 {
     "/api/v1/*": "/$1",
-    "/firm/:id": "/firm"
+    "/firms/:id": "/firms"
 }


### PR DESCRIPTION
Amended the Sirius api endpoint from '/firm' to '/firms' in line with naming conventions. 