### PR TITLE
Move Health Check up in route matching order

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,8 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 	wrap := errorHandler(logger, client, templates["error.gotmpl"], prefix, siriusPublicURL)
 
 	router := mux.NewRouter()
+	router.Handle("/health-check", healthCheck())
+
 	router.Handle("/{id}",
 		wrap(
 			renderTemplateForFirmHub(client, templates["firm-hub.gotmpl"])))
@@ -36,8 +38,6 @@ func New(logger Logger, client Client, templates map[string]*template.Template, 
 	router.Handle("/{id}/manage-pii-details",
 		wrap(
 			renderTemplateForManagePiiDetails(client, templates["manage-pii-details.gotmpl"])))
-
-	router.Handle("/health-check", healthCheck())
 
 	static := staticFileHandler(webDir)
 	router.PathPrefix("/assets/").Handler(static)


### PR DESCRIPTION
Currently the /{id} route is being matched ahead of /health-check, so a page is being returned rather than the empty response and 200 status expected