### PR TITLE
Pin colors to 1.4.0 #patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
         "test-server": "cd internal/server && go test",
         "cypress": "cypress open",
         "fmt": "prettier --write ."
+    },
+    "resolutions": {
+        "colors": "1.4.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1519,9 +1519,9 @@ colorette@^2.0.14, colorette@^2.0.16:
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz"
   integrity sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==
 
-colors@^1.1.2:
+colors@1.4.0, colors@^1.1.2:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:


### PR DESCRIPTION
To ensure we avoid a security issue in >1.4.4.

Can be removed when the package is back under secure control, or our core dependencies stop using it.