### PR TITLE
SW-5450 PII Amount displays in a scientific format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 #### Installing dependencies locally:
 
 -   `yarn install`
--   ## `go mod download`
+-   `go mod download`
 
 ## Local development
 

--- a/cypress/integration/firm_deputy_hub.spec.js
+++ b/cypress/integration/firm_deputy_hub.spec.js
@@ -101,7 +101,7 @@ describe("Firm Deputy Hub", () => {
         it("should show the PII expiry date", () => {
             cy.get(':nth-child(3) > .govuk-summary-list > :nth-child(1) > .govuk-summary-list__value').should("contain", "20/12/2000");
             cy.get(':nth-child(3) > .govuk-summary-list > :nth-child(2) > .govuk-summary-list__value').should("contain", "01/12/2020");
-            cy.get(':nth-child(3) > .govuk-summary-list > :nth-child(3) > .govuk-summary-list__value').should("contain", "1000");
+            cy.get(':nth-child(3) > .govuk-summary-list > :nth-child(3) > .govuk-summary-list__value').should("contain", "1,000");
             cy.get(':nth-child(3) > .govuk-summary-list > :nth-child(4) > .govuk-summary-list__value').should("contain", "15/11/2000");
         });
     });

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/sirius/get_firm_details.go
+++ b/internal/sirius/get_firm_details.go
@@ -46,6 +46,7 @@ type FirmDetails struct {
 	PiiRequestedDateFormat string
 	TotalNumberOfDeputies  int
 	PiiAmountCommaFormat   string
+	PiiAmountIntFormat     int64
 }
 
 func (c *Client) GetFirmDetails(ctx Context, firmId int) (FirmDetails, error) {
@@ -78,7 +79,10 @@ func (c *Client) GetFirmDetails(ctx Context, firmId int) (FirmDetails, error) {
 	v.PiiReceivedDateFormat = reformatDatesForAutofill(v.PiiReceived)
 	v.PiiExpiryDateFormat = reformatDatesForAutofill(v.PiiExpiry)
 	v.PiiRequestedDateFormat = reformatDatesForAutofill(v.PiiRequested)
-	v.PiiAmountCommaFormat = humanize.Commaf(v.PiiAmount)
+	if v.PiiAmount != 0 {
+		v.PiiAmountCommaFormat = humanize.Commaf(v.PiiAmount)
+		v.PiiAmountIntFormat = int64(v.PiiAmount)
+	}
 	return v, err
 }
 

--- a/internal/sirius/get_firm_details.go
+++ b/internal/sirius/get_firm_details.go
@@ -3,6 +3,7 @@ package sirius
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/dustin/go-humanize"
 	"net/http"
 	"time"
 )
@@ -77,7 +78,7 @@ func (c *Client) GetFirmDetails(ctx Context, firmId int) (FirmDetails, error) {
 	v.PiiReceivedDateFormat = reformatDatesForAutofill(v.PiiReceived)
 	v.PiiExpiryDateFormat = reformatDatesForAutofill(v.PiiExpiry)
 	v.PiiRequestedDateFormat = reformatDatesForAutofill(v.PiiRequested)
-
+	v.PiiAmountCommaFormat = humanize.Commaf(v.PiiAmount)
 	return v, err
 }
 

--- a/web/template/firm-hub.gotmpl
+++ b/web/template/firm-hub.gotmpl
@@ -124,7 +124,7 @@
                 <div class="govuk-summary-list__row">
                     <dt class="govuk-summary-list__key">PII amount</dt>
                     <dd class="govuk-summary-list__value">
-                       {{ if ne .FirmDetails.PiiAmount 0.0}}£{{ .FirmDetails.PiiAmount }}{{end}}
+                       {{ if ne .FirmDetails.PiiAmount 0.0}}£{{ .FirmDetails.PiiAmountCommaFormat }}{{end}}
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row">

--- a/web/template/manage-pii-details.gotmpl
+++ b/web/template/manage-pii-details.gotmpl
@@ -106,7 +106,7 @@
                                         {{ end }}
                                     {{ end }}
                                     {{ if ne .FirmDetails.PiiAmount 0.0}}
-                                        value={{ .FirmDetails.PiiAmount }}
+                                        value={{ .FirmDetails.PiiAmountIntFormat }}
                                     {{ end }}
                                     />
                                 </div>


### PR DESCRIPTION
This PR is to address the amount bug which displayed a float64 value as a scientific number. This PR makes use of the humanize library which provides a function to convert float64 into a comma separated value to be displayed on the front end. It includes a change for the "Manage PII details" page as this issue was occurring there as well. 