### PR TITLE
SW-6028 Added assurance visit column to deputies tab

### DIFF
--- a/cypress/e2e/deputies_tab.cy.js
+++ b/cypress/e2e/deputies_tab.cy.js
@@ -29,6 +29,15 @@ describe("Deputies Tab", () => {
             ).contains("-");
         });
 
+        it("shows assurance visit data", () => {
+            cy.get(":nth-child(1) > .visit_type").contains(
+                "26/05/2023"
+            );
+            cy.get(":nth-child(1) > .visit_type > .secondary").contains(
+                "Green"
+            );
+        });
+
         it("shows a dash if no ECM", () => {
             cy.get(
                 ".govuk-table__body > :nth-child(2) > :nth-child(6)"

--- a/cypress/e2e/deputies_tab.cy.js
+++ b/cypress/e2e/deputies_tab.cy.js
@@ -23,9 +23,15 @@ describe("Deputies Tab", () => {
             );
         });
 
+        it("shows a dash if no assurance visit", () => {
+            cy.get(
+                ".govuk-table__body > :nth_child(2) > :nth-child(5)"
+            ).contains("'");
+        });
+
         it("shows a dash if no ECM", () => {
             cy.get(
-                ".govuk-table__body > :nth-child(2) > :nth-child(5)"
+                ".govuk-table__body > :nth-child(2) > :nth-child(6)"
             ).contains("-");
         });
 

--- a/cypress/e2e/deputies_tab.cy.js
+++ b/cypress/e2e/deputies_tab.cy.js
@@ -25,8 +25,8 @@ describe("Deputies Tab", () => {
 
         it("shows a dash if no assurance visit", () => {
             cy.get(
-                ".govuk-table__body > :nth_child(2) > :nth-child(5)"
-            ).contains("'");
+                ".govuk-table__body > :nth-child(2) > :nth-child(5)"
+            ).contains("-");
         });
 
         it("shows a dash if no ECM", () => {

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       dockerfile: ./docker/sirius-firm-deputy-hub/Dockerfile
-    ports: ["8888:1234"]
+    ports: ["8888:8888"]
     environment:
       PORT: 8888
       SIRIUS_URL: http://json-server:3000

--- a/internal/sirius/format_date_and_time.go
+++ b/internal/sirius/format_date_and_time.go
@@ -3,7 +3,7 @@ package sirius
 import "time"
 
 const DateTimeFormat string = "2006-01-02T15:04:05+00:00"
-const DateTimeDisplayFormat string = "01/02/2006"
+const DateTimeDisplayFormat string = "02/01/2006"
 
 func FormatDateAndTime(formatForDateTime string, dateString string, displayLayoutDateTime string) string {
 	if dateString == "" {

--- a/internal/sirius/format_date_and_time.go
+++ b/internal/sirius/format_date_and_time.go
@@ -1,0 +1,15 @@
+package sirius
+
+import "time"
+
+const DateTimeFormat string = "2006-01-02T15:04:05+00:00"
+const DateTimeDisplayFormat string = "01/02/2006"
+
+func FormatDateAndTime(formatForDateTime string, dateString string, displayLayoutDateTime string) string {
+	if dateString == "" {
+		return dateString
+	}
+	stringToDateTime, _ := time.Parse(formatForDateTime, dateString)
+	dateTime := stringToDateTime.Local().Format(displayLayoutDateTime)
+	return dateTime
+}

--- a/internal/sirius/get_firm_deputies.go
+++ b/internal/sirius/get_firm_deputies.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strings"
 )
 
 type orderStatus struct {
@@ -26,6 +27,12 @@ type orders struct {
 	Order order `json:"order"`
 }
 
+type assuranceVisit struct {
+	ReportReviewDate     string  `json:"reportReviewDate"`
+	VisitReportMarkedAs  RefData `json:"assuranceVisitReportMarkedAs"` 
+	AssuranceType        RefData `json:"assuranceType"`  
+}
+
 type executiveCaseManager struct {
 	EcmId   int    `json:"id"`
 	EcmName string `json:"displayName"`
@@ -40,6 +47,7 @@ type Deputies struct {
 	ExecutiveCaseManager executiveCaseManager `json:"executiveCaseManager"`
 	OrganisationName     string               `json:"organisationName"`
 	Town                 string               `json:"town"`
+	AssuranceVisit       assuranceVisit       `json:"mostRecentlyCompletedAssuranceVisit"`
 }
 
 type FirmDeputy struct {
@@ -50,7 +58,18 @@ type FirmDeputy struct {
 	ActiveClientsCount   int
 	ExecutiveCaseManager string
 	OrganisationName     string
-	Town                 string
+	Town                 string  
+	ReviewDate           string
+	MarkedAsLabel        string
+	MarkedAsClass        string
+	AssuranceType        string
+}
+
+
+
+type RefData struct {
+	Handle string `json:"handle"`
+	Label  string `json:"label"`
 }
 
 func (c *Client) GetFirmDeputies(ctx Context, firmId int) ([]FirmDeputy, error) {
@@ -65,7 +84,7 @@ func (c *Client) GetFirmDeputies(ctx Context, firmId int) ([]FirmDeputy, error) 
 	}
 
 	defer resp.Body.Close()
-
+	
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, ErrUnauthorized
 	}
@@ -91,6 +110,10 @@ func (c *Client) GetFirmDeputies(ctx Context, firmId int) ([]FirmDeputy, error) 
 			ExecutiveCaseManager: t.ExecutiveCaseManager.EcmName,
 			OrganisationName:     t.OrganisationName,
 			Town:                 t.Town,
+			AssuranceType:        t.AssuranceVisit.AssuranceType.Label,
+			MarkedAsLabel:        t.AssuranceVisit.VisitReportMarkedAs.Label,
+			MarkedAsClass:        strings.ToLower(t.AssuranceVisit.VisitReportMarkedAs.Label),
+			ReviewDate:           FormatDateAndTime(DateTimeFormat, t.AssuranceVisit.ReportReviewDate, DateTimeDisplayFormat),
 		}
 
 		deputies = append(deputies, deputy)

--- a/internal/sirius/get_firm_deputies_test.go
+++ b/internal/sirius/get_firm_deputies_test.go
@@ -102,7 +102,7 @@ func TestGetFirmDeputiesReturned(t *testing.T) {
 			ActiveClientsCount:   1,
 			ExecutiveCaseManager: "PROTeam1 User1",
 			OrganisationName:     "pro dept",
-			ReviewDate: "05/26/2023",
+			ReviewDate: "26/05/2023",
 			MarkedAsLabel: "Green",
 			MarkedAsClass: "green",
 			AssuranceType: "Visit",

--- a/internal/sirius/get_firm_deputies_test.go
+++ b/internal/sirius/get_firm_deputies_test.go
@@ -15,9 +15,73 @@ func TestGetFirmDeputiesReturned(t *testing.T) {
 	mockClient := &mocks.MockClient{}
 	client, _ := NewClient(mockClient, "http://localhost:3000")
 
-	json := `[
-		{"id":76,"orders":[{"order":{"id":63,"client":{"id":74,"firstname":"Louis","surname":"Dauphin"},"orderStatus":{"handle":"ACTIVE","label":"Active"}}}],"deputyNumber":21,"organisationName":"pro dept","executiveCaseManager":{"id":94,"displayName":"PROTeam1 User1"},"firm":{"id":1}},
-		{"id":77, "firstName":"Louis", "surname":"Devito", "orders":[{"order":{"id":49,"client":{"id":99,"firstname":"Bob","surname":"Mortimer"},"orderStatus":{"handle":"ACTIVE","label":"Active"}}}],"deputyNumber":25,"organisationName":"","executiveCaseManager":{"id":94,"displayName":"PROTeam1 User1"},"firm":{"id":1}}
+	json := `[{
+			"id":76,
+			"orders":[
+				{
+					"order":{
+						"id":63,
+						"client":{
+							"id":74,
+							"firstname":"Louis",
+							"surname":"Dauphin"
+						},
+						"orderStatus":{
+							"handle":"ACTIVE",
+							"label":"Active"
+						}
+					}
+				}
+			],
+			"deputyNumber":21,
+			"organisationName":"pro dept",
+			"executiveCaseManager":{
+				"id":94,
+				"displayName":"PROTeam1 User1"
+			},
+			"firm":{
+				"id":1
+			},
+			"mostRecentlyCompletedAssuranceVisit": {
+				"reportReviewDate" : "2023-05-26T00:00:00+00:00",
+				"assuranceVisitReportMarkedAs": {
+					"handle": "GREEN",
+					"label": "Green"
+				},
+				"assuranceType": {
+					"handle": "VISIT",
+					"label": "Visit"
+				}
+			}
+			
+		},
+		{
+			"id":77, 
+			"firstName":"Louis", 
+			"surname":"Devito", 
+			"orders":[
+				{
+					"order":{
+						"id":49,
+						"client":{
+							"id":99,
+							"firstname":"Bob",
+							"surname":"Mortimer"
+						},
+						"orderStatus":{
+							"handle":"ACTIVE",
+							"label":"Active"
+						}
+					}
+				}
+			],
+			"deputyNumber":25,
+			"organisationName":"",
+			"executiveCaseManager":{"id":94,"displayName":"PROTeam1 User1"},
+			"firm":{
+				"id":1
+			}
+		}
 	]`
 
 	r := io.NopCloser(bytes.NewReader([]byte(json)))
@@ -38,6 +102,10 @@ func TestGetFirmDeputiesReturned(t *testing.T) {
 			ActiveClientsCount:   1,
 			ExecutiveCaseManager: "PROTeam1 User1",
 			OrganisationName:     "pro dept",
+			ReviewDate: "05/26/2023",
+			MarkedAsLabel: "Green",
+			MarkedAsClass: "green",
+			AssuranceType: "Visit",
 		},
 		{
 			Firstname:            "Louis",

--- a/json-server/db.json
+++ b/json-server/db.json
@@ -194,7 +194,18 @@
             "deputySubType": {
                 "handle": "PERSON",
                 "label": "Person"
-            }
+            },
+            "mostRecentlyCompletedAssuranceVisit": {
+				"reportReviewDate" : "2023-05-26T00:00:00+00:00",
+				"assuranceVisitReportMarkedAs": {
+					"handle": "GREEN",
+					"label": "Green"
+				},
+				"assuranceType": {
+					"handle": "VISIT",
+					"label": "Visit"
+				}
+			}
         },
         {
             "id": 86,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "test-sirius": "cd internal/sirius && go test",
         "test-server": "cd internal/server && go test",
         "cypress": "cypress open",
+        "cypress-m1": "export CYPRESS_BASE_URL=http://localhost:8888; cypress open",
         "fmt": "prettier --write ."
     },
     "resolutions": {

--- a/web/assets/scss/firm-hub.scss
+++ b/web/assets/scss/firm-hub.scss
@@ -70,3 +70,24 @@ main {
 .govuk-form-group {
   max-width: 40em;
 }
+
+span.rag {
+  font-weight: bold;
+  &.green {
+    color: #28a197 !important;
+  }
+  &.amber {
+    color: #f47738 !important;
+  }
+  &.red {
+    color: #d4351c !important;
+  }
+}
+
+span.secondary {
+  display: block;
+  color: #505a5f;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+}

--- a/web/template/deputies.gotmpl
+++ b/web/template/deputies.gotmpl
@@ -60,8 +60,12 @@
                            {{ .ActiveClientsCount }}
                         </td>
                         <td class="govuk-table__cell visit_type nowrap">
-                            {{ .ReviewDate }}
-                            <span class="secondary rag {{ .MarkedAsClass }}">{{ .MarkedAsLabel }}</span>
+                            {{ if and .ReviewDate .MarkedAsLabel }}
+                                {{ .ReviewDate }}
+                                <span class="secondary rag {{ .MarkedAsClass }}">{{ .MarkedAsLabel }}</span>
+                            {{ else }}
+                                - 
+                            {{ end }}
                         </td>
                         <td class="govuk-table__cell">
                             {{ if .ExecutiveCaseManager }}

--- a/web/template/deputies.gotmpl
+++ b/web/template/deputies.gotmpl
@@ -26,6 +26,9 @@
                         Active clients
                     </th>
                     <th scope="col" class="govuk-table__header">
+                        Assurance visit
+                    </th>
+                    <th scope="col" class="govuk-table__header">
                         ECM
                     </th>
                 </tr>
@@ -55,6 +58,10 @@
                         </td>
                         <td class="govuk-table__cell">
                            {{ .ActiveClientsCount }}
+                        </td>
+                        <td class="govuk-table__cell visit_type nowrap">
+                            {{ .ReviewDate }}
+                            <span class="secondary rag {{ .MarkedAsClass }}">{{ .MarkedAsLabel }}</span>
                         </td>
                         <td class="govuk-table__cell">
                             {{ if .ExecutiveCaseManager }}


### PR DESCRIPTION
Added 'assurance visit' column to the firm deputies tab, which displays the most recent assurance visit for each deputy.